### PR TITLE
Add GNOME Shell version 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/faymaz/dexcom",
   "uuid": "dexcom@faymaz.github.com",


### PR DESCRIPTION
This commit makes the extension compatible with GNOME Shell `48.x`.
I tested it using GNOME Shell `48.1` on an Arch Linux installation and it worked flawlessly so far.